### PR TITLE
refactor: reorganize packages into domain, app, and infra

### DIFF
--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/BatchConfig.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/BatchConfig.java
@@ -1,11 +1,11 @@
-package com.ali.batchoptimizer.batch.config;
+package com.ali.batchoptimizer.app.jobs;
 
 
 
-import com.ali.batchoptimizer.batch.listener.ConversationCacheInitializer;
-import com.ali.batchoptimizer.batch.model.ConversationResult;
-import com.ali.batchoptimizer.batch.processor.ConversationProcessor;
-import com.ali.batchoptimizer.batch.writer.ConversationWriter;
+import com.ali.batchoptimizer.app.jobs.listener.ConversationCacheInitializer;
+import com.ali.batchoptimizer.app.jobs.processor.ConversationProcessor;
+import com.ali.batchoptimizer.app.jobs.writer.ConversationWriter;
+import com.ali.batchoptimizer.domain.ConversationResult;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/BatchLauncher.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/BatchLauncher.java
@@ -1,4 +1,4 @@
-package com.ali.batchoptimizer.batch.config;
+package com.ali.batchoptimizer.app.jobs;
 
 
 

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/listener/ConversationCacheInitializer.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/listener/ConversationCacheInitializer.java
@@ -1,9 +1,9 @@
-package com.ali.batchoptimizer.batch.listener;
+package com.ali.batchoptimizer.app.jobs.listener;
 
 
 
-import com.ali.batchoptimizer.batch.service.ConversationService;
-import com.ali.batchoptimizer.batch.service.MediaTypeService;
+import com.ali.batchoptimizer.domain.ConversationService;
+import com.ali.batchoptimizer.domain.MediaTypeService;
 import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/processor/ConversationProcessor.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/processor/ConversationProcessor.java
@@ -1,9 +1,9 @@
-package com.ali.batchoptimizer.batch.processor;
+package com.ali.batchoptimizer.app.jobs.processor;
 
 
 
-import com.ali.batchoptimizer.batch.listener.ConversationCacheInitializer;
-import com.ali.batchoptimizer.batch.model.ConversationResult;
+import com.ali.batchoptimizer.app.jobs.listener.ConversationCacheInitializer;
+import com.ali.batchoptimizer.domain.ConversationResult;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/reader/ConversationReader.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/reader/ConversationReader.java
@@ -1,7 +1,7 @@
-package com.ali.batchoptimizer.batch.reader;
+package com.ali.batchoptimizer.app.jobs.reader;
 
 
-import com.ali.batchoptimizer.batch.model.ConversationResult;
+import com.ali.batchoptimizer.domain.ConversationResult;
 import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/writer/ConversationWriter.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/app/jobs/writer/ConversationWriter.java
@@ -1,6 +1,6 @@
-package com.ali.batchoptimizer.batch.writer;
+package com.ali.batchoptimizer.app.jobs.writer;
 
-import com.ali.batchoptimizer.batch.model.ConversationResult;
+import com.ali.batchoptimizer.domain.ConversationResult;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/domain/ConversationResult.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/domain/ConversationResult.java
@@ -1,4 +1,4 @@
-package com.ali.batchoptimizer.batch.model;
+package com.ali.batchoptimizer.domain;
 
 
 import lombok.AllArgsConstructor;

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/domain/ConversationService.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/domain/ConversationService.java
@@ -1,4 +1,4 @@
-package com.ali.batchoptimizer.batch.service;
+package com.ali.batchoptimizer.domain;
 
 import java.util.List;
 

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/domain/MediaTypeService.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/domain/MediaTypeService.java
@@ -1,4 +1,4 @@
-package com.ali.batchoptimizer.batch.service;
+package com.ali.batchoptimizer.domain;
 
 import java.util.List;
 import java.util.Map;

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/infra/adapters/FakeConversationService.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/infra/adapters/FakeConversationService.java
@@ -1,6 +1,7 @@
-package com.ali.batchoptimizer.batch.service;
+package com.ali.batchoptimizer.infra.adapters;
 
 
+import com.ali.batchoptimizer.domain.ConversationService;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/batchoptimizer/src/main/java/com/ali/batchoptimizer/infra/adapters/FakeMediaTypeService.java
+++ b/batchoptimizer/src/main/java/com/ali/batchoptimizer/infra/adapters/FakeMediaTypeService.java
@@ -1,6 +1,7 @@
-package com.ali.batchoptimizer.batch.service;
+package com.ali.batchoptimizer.infra.adapters;
 
 
+import com.ali.batchoptimizer.domain.MediaTypeService;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;


### PR DESCRIPTION
## Summary
- move ConversationResult and business service interfaces into domain
- reorganize batch components under app/jobs
- relocate fake service implementations into infra/adapters

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b708812248832c8dd372f1bcef4331